### PR TITLE
fix: add x11-utils to fix new ubuntu image

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ async function run() {
     if (process.platform === 'linux') {
       await exec.exec('sudo apt-get update')
       await exec.exec(
-        'sudo apt-get install -y libegl1 libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0'
+        'sudo apt-get install -y libegl1 libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 x11-utils'
       )
     }
   } catch (error) {


### PR DESCRIPTION
As found in vispy/vispy#2356, the new ubuntu image is now missing `x11-utils`. If I understand correctly, we should update it here to get it to work in napari!
