### PR TITLE
Drop libegl1-mesa (libegl1 suffices)

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -27877,11 +27877,11 @@ const exec = __nccwpck_require__(1514);
 async function run() {
   try {
     // Qt installer assumes basic requirements that are not installed by
-    // default on Ubuntu.
+    // default on Ubuntu. 20.04 and newer only.
     if (process.platform === 'linux') {
       await exec.exec('sudo apt-get update')
       await exec.exec(
-        'sudo apt-get install -y libegl1 libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 x11-utils libxcb-cursor0 libopengl0 libegl1-mesa'
+        'sudo apt-get install -y libegl1 libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 x11-utils libxcb-cursor0 libopengl0'
       )
     }
   } catch (error) {


### PR DESCRIPTION
Closes https://github.com/tlambert03/setup-qt-libs/issues/65

As noted https://github.com/tlambert03/setup-qt-libs/issues/65#issuecomment-2408128287 it appears that libegl1-mesa was a transitional dummy package for libegl1, going back as far as 20.04
So dropping it and just using libegl1 should suffice. I tested my branch here:
https://github.com/psobolewskiPhD/i2k2024_napari_workshop/commit/95fb7090365137fa1f00caedbf55eed98f1172ce
and my action worked.
Not sure how else to test.

It's possible this works all the way back to ubuntu 18, but GitHub doesn't have those runners anymore, so it shouldn't matter?